### PR TITLE
Populate library.properties url field

### DIFF
--- a/Nunchuk/library.properties
+++ b/Nunchuk/library.properties
@@ -5,5 +5,5 @@ maintainer=Eduardo Cáceres de la Calle <edcaceres95@hotmail.com>
 sentence= Controls motor and servomotor via nunchuk
 paragraph=This library allows an Arduino board to control a motor and a servomotor based on the movements of a nunchuk
 category=Display
-url=*
+url=https://github.com/eduherminio/Nunchuck
 architectures=*


### PR DESCRIPTION
A empty url field results in an apparently clickable "More info" link in Library Manager that does nothing.