### PR TITLE
Use a single tab field separator in keywords.txt

### DIFF
--- a/Nunchuk/keywords.txt
+++ b/Nunchuk/keywords.txt
@@ -2,20 +2,20 @@
 
 # Datatypes (KEYWORD1)
 
-Nunchuk 	KEYWORD1
-Wire		KEYWORD1	Wire
+Nunchuk	KEYWORD1
+Wire	KEYWORD1	Wire
 
 # Methods and Functions (KEYWORD2)
 
-init				KEYWORD2
-_sendByte			KEYWORD2
-update				KEYWORD2
-begin				KEYWORD2
-requestFrom			KEYWORD2
-available			KEYWORD2
+init	KEYWORD2
+_sendByte	KEYWORD2
+update	KEYWORD2
+begin	KEYWORD2
+requestFrom	KEYWORD2
+available	KEYWORD2
 beginTransmission	KEYWORD2
-endTransmission		KEYWORD2
-write				KEYWORD2
-read				KEYWORD2
+endTransmission	KEYWORD2
+write	KEYWORD2
+read	KEYWORD2
 
 


### PR DESCRIPTION
Each field of keywords.txt is separated by a single true tab. When you use multiple tabs it causes the field to be interpreted as empty. On Arduino IDE 1.6.5 and newer an empty KEYWORD_TOKENTYPE causes the default editor.function.style highlighting  to be used (as with KEYWORD2, KEYWORD3). On Arduino IDE 1.6.4 and older it causes the keyword to not be recognized for any special highlighting.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords